### PR TITLE
Manage experiment Phase and show surveys.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
 dist/
+pioneer-study-online-news.xpi

--- a/bin/make-xpi.sh
+++ b/bin/make-xpi.sh
@@ -19,7 +19,7 @@ trap cleanup EXIT
 # fill templates, could be fancier
 node_modules/.bin/mustache addon.json templates/install.rdf.mustache > "${DEST}/install.rdf"
 node_modules/.bin/mustache addon.json templates/chrome.manifest.mustache > "${DEST}/chrome.manifest"
-cp node_modules/pioneer-studies-addon-utils/dist/PioneerUtils.jsm "${DEST}"
+cp node_modules/pioneer-utils/dist/PioneerUtils.jsm "${DEST}"
 
 cp -rp extension/* "$DEST"
 

--- a/extension/Config.jsm
+++ b/extension/Config.jsm
@@ -1,0 +1,67 @@
+const { utils: Cu } = Components;
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+
+const EXPORTED_SYMBOLS = ["Config"];
+
+const HOUR = 1000 * 60 * 60;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+
+const Config = {
+  studyName: "news",
+  schemaVersion: 1,
+  branches: [
+    { name: "control", weight: 1 },
+    { name: "treatment", weight: 1 },
+  ],
+
+  updateTimerInterval: 1000,
+
+  /**
+   * @typedef {Object} Phase
+   * @property {number?} duration
+   *    Time before automatically transitioning to the next phase, in
+   *    milliseconds. If null or not specified, no automatic
+   *    transition will occur. Set to 0 to show the postUrl
+   *    immediately.
+   * @property {string?} next
+   *    Optional. Phase to transition to next. If null or not
+   *    specified, no automatic transition will occur.
+   * @property {string?} surveyURL
+   *    Optional. Url of a page tied to this phase. If specified, at
+   *    the start of the phase, a prompt to view this page will be
+   *    shown. Will be repeated one a day, up to promptRepeat times.
+   * @property {number?} promptRepeat
+   *    Optional. Number of times to prompt the user to view the
+   *    surveyURL. Defaults to 3.
+   * @property {boolean?} lastPhase
+   *    Optional. If true, upon reaching this state the study will end.
+   */
+
+  firstPhase: 'preTreatment',
+
+  phases: {
+    preTreatment: {
+      duration: 5000, // 3 * WEEK,
+      next: 'treatment',
+      surveyURL: "data:text/plain;charset=UTF-8,online-news phase = preTreatment",
+    },
+
+    treatment: {
+      duration: 5000, // 3 * WEEK,
+      next: 'postTreatment',
+      surveyURL: "data:text/plain;charset=UTF-8,online-news phase = treatment",
+      promptRepeat: 2,
+    },
+
+    postTreatment: {
+      duration: 5000, // 3 * WEEK,
+      next: 'studyEnd',
+      surveyURL: "data:text/plain;charset=UTF-8,online-news phase = postTreatment",
+    },
+
+    studyEnd: {
+      lastPhase: true,
+    }
+  }
+};

--- a/extension/Config.jsm
+++ b/extension/Config.jsm
@@ -8,8 +8,8 @@ const DAY = 24 * HOUR;
 const WEEK = 7 * DAY;
 
 const Config = {
-  studyName: "news",
-  schemaVersion: 1,
+  addonId: "pioneer-study-online-news@mozilla.org",
+  studyName: "online-news",
   branches: [
     { name: "control", weight: 1 },
     { name: "treatment", weight: 1 },
@@ -45,26 +45,26 @@ const Config = {
 
   phases: {
     preTreatment: {
-      duration: 5000, // 3 * WEEK,
+      duration: 3 * WEEK,
       next: 'treatment',
       surveyURL: "https://qsurvey.mozilla.com/s3/Pioneer-Online-News-Wave-1",
     },
 
     treatment: {
-      duration: 5000, // 3 * WEEK,
+      duration: 3 * WEEK,
       next: 'postTreatment',
       surveyURL: "https://qsurvey.mozilla.com/s3/Pioneer-Online-News-Wave-2",
       promptRepeat: 2,
     },
 
     postTreatment: {
-      duration: 5000, // 3 * WEEK,
+      duration: 3 * WEEK,
       next: 'postStudy',
       surveyURL: "https://qsurvey.mozilla.com/s3/Pioneer-Online-News-Wave-3",
     },
 
     postStudy: {
-      duration: 5000, // 1 * WEEK,
+      duration: 1 * WEEK,
       surveyOnly: true,
       next: 'studyEnd',
       surveyURL: "https://qsurvey.mozilla.com/s3/Pioneer-Online-News-Wave-4",

--- a/extension/Config.jsm
+++ b/extension/Config.jsm
@@ -34,6 +34,9 @@ const Config = {
    * @property {number?} promptRepeat
    *    Optional. Number of times to prompt the user to view the
    *    surveyURL. Defaults to 3.
+   * @property {boolean?} surveyOnly
+   *    Once a survey has been given to the user, go to the next
+   *    phase, regardless of the time spend.
    * @property {boolean?} lastPhase
    *    Optional. If true, upon reaching this state the study will end.
    */
@@ -44,20 +47,27 @@ const Config = {
     preTreatment: {
       duration: 5000, // 3 * WEEK,
       next: 'treatment',
-      surveyURL: "data:text/plain;charset=UTF-8,online-news phase = preTreatment",
+      surveyURL: "https://qsurvey.mozilla.com/s3/Pioneer-Online-News-Wave-1",
     },
 
     treatment: {
       duration: 5000, // 3 * WEEK,
       next: 'postTreatment',
-      surveyURL: "data:text/plain;charset=UTF-8,online-news phase = treatment",
+      surveyURL: "https://qsurvey.mozilla.com/s3/Pioneer-Online-News-Wave-2",
       promptRepeat: 2,
     },
 
     postTreatment: {
       duration: 5000, // 3 * WEEK,
+      next: 'postStudy',
+      surveyURL: "https://qsurvey.mozilla.com/s3/Pioneer-Online-News-Wave-3",
+    },
+
+    postStudy: {
+      duration: 5000, // 1 * WEEK,
+      surveyOnly: true,
       next: 'studyEnd',
-      surveyURL: "data:text/plain;charset=UTF-8,online-news phase = postTreatment",
+      surveyURL: "https://qsurvey.mozilla.com/s3/Pioneer-Online-News-Wave-4",
     },
 
     studyEnd: {

--- a/extension/bootstrap.js
+++ b/extension/bootstrap.js
@@ -8,14 +8,34 @@ Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.importGlobalProperties(['fetch']);
 
 XPCOMUtils.defineLazyModuleGetter(
+  this, "Config", "resource://pioneer-study-online-news/Config.jsm"
+);
+XPCOMUtils.defineLazyModuleGetter(
   this, "ActiveURIService", "resource://pioneer-study-online-news/lib/ActiveURIService.jsm",
 );
 XPCOMUtils.defineLazyModuleGetter(
   this, "DwellTime", "resource://pioneer-study-online-news/lib/DwellTime.jsm",
 );
+XPCOMUtils.defineLazyModuleGetter(
+  this, "State", "resource://pioneer-study-online-news/lib/State.jsm"
+);
+XPCOMUtils.defineLazyModuleGetter(
+  this, "Phases", "resource://pioneer-study-online-news/lib/Phases.jsm"
+);
 
-const REASON_APP_STARTUP = 1;
+const TIMER_NAME = "pioneer-online-news-study-state";
+const REASONS = {
+  APP_STARTUP:      1, // The application is starting up.
+  APP_SHUTDOWN:     2, // The application is shutting down.
+  ADDON_ENABLE:     3, // The add-on is being enabled.
+  ADDON_DISABLE:    4, // The add-on is being disabled. (Also sent during uninstallation)
+  ADDON_INSTALL:    5, // The add-on is being installed.
+  ADDON_UNINSTALL:  6, // The add-on is being uninstalled.
+  ADDON_UPGRADE:    7, // The add-on is being upgraded.
+  ADDON_DOWNGRADE:  8, // The add-on is being downgraded.
+};
 const UI_AVAILABLE_NOTIFICATION = "sessionstore-windows-restored";
+const STATE_PREF = "extensions.pioneer-online-news.state";
 
 this.Bootstrap = {
   install() {},
@@ -23,7 +43,7 @@ this.Bootstrap = {
   startup(data, reason) {
     // If the app is starting up, wait until the UI is available before finishing
     // init.
-    if (reason === REASON_APP_STARTUP) {
+    if (reason === REASONS.APP_STARTUP) {
       Services.obs.addObserver(this, UI_AVAILABLE_NOTIFICATION);
     } else {
       this.finishStartup();
@@ -37,6 +57,10 @@ this.Bootstrap = {
     }
   },
 
+  /**
+   * Add-on startup tasks delayed until after session restore so as
+   * not to slow down browser startup.
+   */
   async finishStartup() {
     const domainResponse = await fetch("resource://pioneer-study-online-news/domains.json");
     const domains = await domainResponse.json();
@@ -44,6 +68,7 @@ this.Bootstrap = {
 
     ActiveURIService.startup();
     DwellTime.startup(trackedHosts);
+    Phases.startup();
   },
 
   shutdown(data, reason) {
@@ -54,11 +79,19 @@ this.Bootstrap = {
       // It must already be removed!
     }
 
+    if (reason === REASONS.ADDONS_UNINSTALL) {
+      State.clear();
+    }
+
     DwellTime.shutdown();
     ActiveURIService.shutdown();
+    Phases.shutdown();
 
+    Cu.unload("resource://pioneer-study-online-news/Config.jsm");
     Cu.unload("resource://pioneer-study-online-news/lib/ActiveURIService.jsm");
     Cu.unload("resource://pioneer-study-online-news/lib/DwellTime.jsm");
+    Cu.unload("resource://pioneer-study-online-news/lib/Phases.jsm");
+    Cu.unload("resource://pioneer-study-online-news/lib/State.jsm");
   },
 
   uninstall() {},

--- a/extension/lib/Phases.jsm
+++ b/extension/lib/Phases.jsm
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { utils: Cu } = Components;
+Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://gre/modules/Timer.jsm");
+
+XPCOMUtils.defineLazyModuleGetter(
+  this, "AddonManager", "resource://gre/modules/AddonManager.jsm"
+);
+XPCOMUtils.defineLazyModuleGetter(
+  this, "RecentWindow", "resource:///modules/RecentWindow.jsm"
+);
+XPCOMUtils.defineLazyServiceGetter(
+  this, "timerManager", "@mozilla.org/updates/timer-manager;1", "nsIUpdateTimerManager"
+);
+
+XPCOMUtils.defineLazyModuleGetter(
+  this, "Config", "resource://pioneer-study-online-news/Config.jsm"
+);
+XPCOMUtils.defineLazyModuleGetter(
+  this, "State", "resource://pioneer-study-online-news/lib/State.jsm"
+);
+
+this.EXPORTED_SYMBOLS = ["Phases"];
+
+this.Phases = {
+  updateStateMachineInterval: null,
+
+  startup() {
+    // for < 10 minute timers, use set interval for testing purposes
+    if (Config.updateTimerInterval < 1000 * 60 * 10) {
+      this.updateStateMachineInterval = setInterval(this.updateStateMachine.bind(this), Config.updateTimerInterval);
+    } else {
+      timerManager.registerTimer(TIMER_NAME, this.updateStateMachine.bind(this), Config.updateTimerInterval);
+    }
+  },
+
+  shutdown() {
+    if (this.updateStateMachineInterval) {
+      clearInterval(this.updateStateMachineInterval);
+    } else {
+      timerManager.unregisterTimer(TIMER_NAME);
+    }
+  },
+
+  /**
+   * Checks current phase and phase change criteria. Called via
+   * persistent timer.
+   */
+  updateStateMachine() {
+    let state = State.load();
+    let phase = Config.phases[state.phaseName];
+
+    if (!phase) {
+      throw new Error(`Unknown study phase ${state.phaseName}`);
+    }
+
+    const now = Date.now();
+    const sinceLastTransition = now - state.lastTransition;
+    if (phase.duration && sinceLastTransition >= phase.duration) {
+      state = State.update({ phaseName: phase.next, lastTransition: Date.now() });
+      phase = Config.phases[state.phaseName];
+      if (!phase) {
+        throw new Error(`Unknown next phase ${state.phaseName}`);
+      }
+    }
+
+    if (phase.lastPhase) {
+      this.endStudy();
+      return;
+    }
+
+    if (phase.surveyURL) {
+      this.showSurvey(phase.surveyURL);
+    }
+  },
+
+  /**
+   * Prompts the user to take a survey.
+   */
+  showSurvey() {
+    // TODO: show doorhanger instead of opening tab directly
+    // TODO: Only show a survey once per ${INTERVAL}.
+
+    const state = State.load();
+    const phase = Config.phases[state.phaseName];
+
+    if (!state.promptsRemaining.hasOwnProperty(state.phaseName)) {
+      state.promptsRemaining[state.phaseName] = phase.promptRepeat || 3;
+    }
+
+    if (state.promptsRemaining[state.phaseName] > 0) {
+      state.promptsRemaining[state.phaseName] -= 1;
+      State.save(state);
+      const recentWindow = RecentWindow.getMostRecentBrowserWindow({
+        private: false,
+        allowPopups: false,
+      });
+      if (recentWindow && recentWindow.gBrowser) {
+        // TODO: add pioneerID and utm_source parameters to surveyURL
+        const tab = recentWindow.gBrowser.loadOneTab(phase.surveyURL, { inBackground: false });
+      }
+    }
+  },
+
+  // TODO this should be from pioneer-utils
+  async endStudy() {
+    let addon = await AddonManager.getAddonByID('pioneer-study-online-news@mozilla.org');
+    if (addon) {
+      addon.uninstall();
+    } else {
+      throw new Error("Could not find self to uninstall");
+    }
+  },
+};

--- a/extension/lib/Phases.jsm
+++ b/extension/lib/Phases.jsm
@@ -18,6 +18,9 @@ XPCOMUtils.defineLazyServiceGetter(
 );
 
 XPCOMUtils.defineLazyModuleGetter(
+  this, "PioneerUtils", "resource://pioneer-study-online-news/PioneerUtils.jsm"
+);
+XPCOMUtils.defineLazyModuleGetter(
   this, "Config", "resource://pioneer-study-online-news/Config.jsm"
 );
 XPCOMUtils.defineLazyModuleGetter(
@@ -76,7 +79,7 @@ this.Phases = {
     }
 
     if (phase.lastPhase) {
-      this.endStudy();
+      PioneerUtils.endStudy();
       return;
     }
 
@@ -112,16 +115,6 @@ this.Phases = {
       }
     } else if (phase.surveyOnly) {
       this.gotoNextPhase();
-    }
-  },
-
-  // TODO this should be from pioneer-utils
-  async endStudy() {
-    let addon = await AddonManager.getAddonByID('pioneer-study-online-news@mozilla.org');
-    if (addon) {
-      addon.uninstall();
-    } else {
-      throw new Error("Could not find self to uninstall");
     }
   },
 };

--- a/extension/lib/Phases.jsm
+++ b/extension/lib/Phases.jsm
@@ -61,11 +61,18 @@ this.Phases = {
     const now = Date.now();
     const sinceLastTransition = now - state.lastTransition;
     if (phase.duration && sinceLastTransition >= phase.duration) {
-      state = State.update({ phaseName: phase.next, lastTransition: Date.now() });
-      phase = Config.phases[state.phaseName];
-      if (!phase) {
-        throw new Error(`Unknown next phase ${state.phaseName}`);
-      }
+      this.gotoNextPhase();
+    }
+  },
+
+  /** Unconditionally goes to the next phase. */
+  gotoNextPhase() {
+    let state = State.read();
+    let phase = Config.phases[state.phaseName];
+    state = State.update({ phaseName: phase.next, lastTransition: Date.now() });
+    phase = Config.phases[state.phaseName];
+    if (!phase) {
+      throw new Error(`Unknown next phase ${state.phaseName}`);
     }
 
     if (phase.lastPhase) {
@@ -103,6 +110,8 @@ this.Phases = {
         // TODO: add pioneerID and utm_source parameters to surveyURL
         const tab = recentWindow.gBrowser.loadOneTab(phase.surveyURL, { inBackground: false });
       }
+    } else if (phase.surveyOnly) {
+      this.gotoNextPhase();
     }
   },
 

--- a/extension/lib/State.jsm
+++ b/extension/lib/State.jsm
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { utils: Cu } = Components;
+Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+
+XPCOMUtils.defineLazyModuleGetter(
+  this, "Config", "resource://pioneer-study-online-news/Config.jsm"
+);
+
+this.EXPORTED_SYMBOLS = ["State"];
+
+const STATE_PREF = "extensions.pioneer-online-news.state";
+
+XPCOMUtils.defineLazyGetter(this, "DEFAULT_STATE", () => {
+  return {
+    phaseName: Config.firstPhase,
+    lastTransition: Date.now(),
+    promptsRemaining: {},
+  };
+});
+
+this.State = {
+  load() {
+    const stateJson = Services.prefs.getCharPref(STATE_PREF, "");
+    try {
+      return JSON.parse(stateJSON);
+    } catch (err) {
+      this.save(DEFAULT_STATE);
+      return DEFAULT_STATE;
+    }
+  },
+
+  save(newState) {
+    Services.prefs.setCharPref(STATE_PREF, JSON.stringify(newState));
+  },
+
+  update(updates) {
+    const newState = Object.assign(this.load(), updates);
+    this.save(newState);
+    return newState;
+  },
+
+  clear() {
+    Services.prefs.clearUserPref(STATE_PREF);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,10 @@
       "integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA=",
       "dev": true
     },
-    "pioneer-studies-addon-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pioneer-studies-addon-utils/-/pioneer-studies-addon-utils-1.0.1.tgz",
-      "integrity": "sha512-1AhlBl/FO4EcRqWoEBF2X7BYFgl4FcmpV5bQAkMFRh01OHUFvZvG+bO9XfFf0nYqZfWW5YfiRJZU1OI9nTQ7UA==",
-      "dev": true
+    "pioneer-utils": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pioneer-utils/-/pioneer-utils-1.0.4.tgz",
+      "integrity": "sha1-ieijNUqEul8YC6dfm6JOE0QS+Xg="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,10 @@
       "dev": true
     },
     "pioneer-utils": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/pioneer-utils/-/pioneer-utils-1.0.4.tgz",
-      "integrity": "sha1-ieijNUqEul8YC6dfm6JOE0QS+Xg="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pioneer-utils/-/pioneer-utils-1.0.5.tgz",
+      "integrity": "sha1-/T8Nq2colDqw9mATy3WVAGUjPN8=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Mozilla",
   "license": "MPL-2.0",
   "devDependencies": {
-    "mustache": "2.3.0"
+    "mustache": "^2.3.0",
+    "pioneer-utils": "^1.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
   "author": "Mozilla",
   "license": "MPL-2.0",
   "devDependencies": {
-    "mustache": "2.3.0",
-    "pioneer-studies-addon-utils": "1.0.1"
-  },
-  "dependencies": {}
+    "mustache": "2.3.0"
+  }
 }


### PR DESCRIPTION
This adds a list of phases to `Config.jsm`, and advances through them on schedule. "Surveys" are shown at the beginning of each phase. Right now the timer is really fast for testing purposes. We'll probably need to slow this down, but it really helps in verifying this PR.